### PR TITLE
Update bulk reindex script

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Install requirements with:
 
 Run with:
 
+    (venv)$ export ES2_ORIGIN_HOST="http://localhost:9200"
+    (venv)$ export ES5_TARGET_HOST="http://localhost:9206"
     (venv)$ python scripts/bulk_index_es2_to_es5.py
 
 Given pre-existing target indices on an ES5 instance, migrate docs for the equivalent ES2 indices to the new indicies.
@@ -33,6 +35,7 @@ https://github.com/alphagov/rummager/tree/master/config/schema/indexes
 
 Run with:
 
+    (venv)$ export ES2_ORIGIN_HOST="http://localhost:9200"
     (venv)$ python scripts/backup_and_restore.py [--create] [--restore]
 
 A work-in-progress script that uses Elasticsearch's built-in snapshot feature to save backups to an ES data folder.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@
 
 elasticsearch2
 elasticsearch5
+six

--- a/scripts/backup_and_restore.py
+++ b/scripts/backup_and_restore.py
@@ -6,6 +6,7 @@ In theory this should work when restoring an ES2 snapshot to an ES5 cluster.
 
 """
 import argparse
+import os
 from datetime import datetime
 
 
@@ -26,8 +27,7 @@ REPOSITORY_DIR = "/tmp"
 # Using the GOV.UK indices as an example
 INDICES = "govuk,government,detailed,metasearch,page-traffic"
 
-# TODO: pass Elasticsearch host as script arg
-ES5_TARGET_PORT = "http://localhost:9202"
+ES5_TARGET_PORT = os.getenv('ES5_TARGET_HOST', 'http://localhost:9205')
 
 es_client5 = Elasticsearch5([ES5_TARGET_PORT])
 

--- a/scripts/bulk_index_es2_to_es5.py
+++ b/scripts/bulk_index_es2_to_es5.py
@@ -13,6 +13,7 @@ from elasticsearch5 import Elasticsearch as Elasticsearch5, TransportError as Tr
 from elasticsearch5.helpers import bulk
 from datetime import datetime
 from six import iteritems
+import os
 
 # Using the example indices and doc types from GOV.UK's search API
 # https://github.com/alphagov/rummager/tree/master/config/schema/indexes
@@ -57,9 +58,8 @@ DOC_TYPES = [
     'utaac_decision'
 ]
 
-# TODO: pass Elasticsearch hosts for source and target as script args
-ES2_HOST_PORT = "http://localhost:9200"
-ES5_TARGET_PORT = "http://elastic:changeme@localhost:9202"
+ES2_HOST_PORT = os.getenv('ES2_ORIGIN_HOST', 'http://localhost:9200')
+ES5_TARGET_PORT = os.getenv('ES5_TARGET_HOST', 'http://localhost:9205')
 
 es_client2 = Elasticsearch2([ES2_HOST_PORT])
 es_client5 = Elasticsearch5([ES5_TARGET_PORT])

--- a/scripts/bulk_index_es2_to_es5.py
+++ b/scripts/bulk_index_es2_to_es5.py
@@ -18,7 +18,7 @@ from six import iteritems
 # https://github.com/alphagov/rummager/tree/master/config/schema/indexes
 
 INDICES = [
-    'page-traffic-new',
+    'page-traffic',
     'metasearch',
     'govuk',
     'government',

--- a/scripts/bulk_index_es2_to_es5.py
+++ b/scripts/bulk_index_es2_to_es5.py
@@ -23,7 +23,6 @@ INDICES = [
     'govuk',
     'government',
     'detailed',
-    'govuk',
 ]
 DOC_TYPES = [
     'aaib_report',

--- a/scripts/bulk_index_es2_to_es5.py
+++ b/scripts/bulk_index_es2_to_es5.py
@@ -167,17 +167,19 @@ def copy_index(index_name_from, index_name_to, bulk_index=True):
 
 def main():
     """
-    Bulk copy documents as-is from one index to another 'new' index.
+    Bulk copy documents as-is from one index to the new index created by rummager.
 
     Assumes the target index has already been created with an appropriate mapping.
     # TODO: create target index if it doesn't exist
 
     Aliases/index names are treated the same.
-    # TODO: swap alias to point to 'new' index after successful creation
     :return:
     """
-    indices = [(index, "{}-new".format(index)) for index in INDICES
-    ]
+    indices = []
+    try:
+        indices = [(index, es_client5.indices.get_alias("{}-*".format(index)).keys()[0]) for index in INDICES]
+    except KeyError as err:
+        print("Index does not exist in ES5 target host: {}".format(index))
     for index_name_from, index_name_to in indices:
         copy_index(index_name_from, index_name_to)
 

--- a/scripts/bulk_index_es2_to_es5.py
+++ b/scripts/bulk_index_es2_to_es5.py
@@ -71,8 +71,10 @@ def count_docs_for_doctype(client, doc_type, index):
 
 def _prepare_docs_for_bulk_insert(docs):
     for doc in docs:
-        yield doc['_source']
-
+        yield {
+            "_id": doc['_id'],
+            "_source": doc['_source'],
+        }
 
 def bulk_index_documents_to_es5(index_name, doc_type, documents):
     try:


### PR DESCRIPTION
PR fixes various issues and makes a number of improvements:
* Remove duplicated `govuk` index from list of indices
* `page-traffix-new` is renamed to `page-traffic`
* Rummager created index names are used instead of appending `-new` (this makes an assumption there is only one index prefixed by that name)
* Elasticsearch paths are now determinable through environment variables so the script doesn't have to be edited before running
* Added six as a pip requirement
* Document `_id` parameters are preserved when doing a bulk import

Trello card: https://trello.com/c/aUWoCoKa/14-make-some-changes-to-es5-re-index-script