### PR TITLE
Add statutory instrument document type

### DIFF
--- a/scripts/bulk_index_es2_to_es5.py
+++ b/scripts/bulk_index_es2_to_es5.py
@@ -54,6 +54,7 @@ DOC_TYPES = [
     'service_manual_guide',
     'service_manual_topic',
     'service_standard_report',
+    'statutory_instrument',
     'tax_tribunal_decision',
     'utaac_decision'
 ]


### PR DESCRIPTION
There doesn't seem a convenient way to get a list of types using the
elasticsearch2 module, so I've just added it to the list here.

---

Also, I'm pretty sure I discovered this issue during the initial search-api elasticsearch 5 compatibility testing, but I guess I never committed the fix, and it got lost at some point...

---

[Trello card](https://trello.com/c/SlBwQAq3/36-index-existing-data-in-cluster-in-integration)