### PR TITLE
Fix fragilities in document importing

### DIFF
--- a/scripts/bulk_index_es2_to_es5.py
+++ b/scripts/bulk_index_es2_to_es5.py
@@ -70,6 +70,13 @@ def count_docs_for_doctype(client, doc_type, index):
     return client.count(index=index, doc_type=doc_type)['count']
 
 
+def index_individual_docs(index, doc_type, docs):
+    for doc in docs:
+        result, status_code = index_document_to_es5(index, doc_type, doc)
+        if status_code != 200:
+            print(result, status_code)
+
+
 def _prepare_docs_for_bulk_insert(docs):
     for doc in docs:
         yield {
@@ -86,13 +93,8 @@ def bulk_index_documents_to_es5(index_name, doc_type, documents):
             doc_type=doc_type,
             chunk_size=100
         )
-        return "acknowledged", 200
     except TransportError5 as e:
-        print(
-            "Failed to bulk index the %s documents: %s",
-            doc_type, str(e)
-        )
-        return str(e), e.status_code
+        index_individual_docs(index_name, doc_type, documents)
 
 
 def index_document_to_es5(index_name, doc_type, document):
@@ -124,13 +126,6 @@ def fetch_documents_from_es2(doc_type, from_=0, page_size=100, index_name='govuk
         return str(e), e.status_code
 
 
-def index_individual_docs(index, doc_type, docs):
-    for doc in docs:
-        result, status_code = index_document_to_es5(index, doc_type, doc)
-        if status_code != 200:
-            print(result, status_code)
-
-
 def list_docs_for_each_doctype(index_name):
     es2_doc_counts = {}
     for doc_type in DOC_TYPES:
@@ -141,7 +136,7 @@ def list_docs_for_each_doctype(index_name):
     return es2_doc_counts
 
 
-def copy_index(index_name_from, index_name_to, bulk_index=True):
+def copy_index(index_name_from, index_name_to):
     start = datetime.now()
 
     es2_doc_counts = list_docs_for_each_doctype(index_name_from)
@@ -160,12 +155,7 @@ def copy_index(index_name_from, index_name_to, bulk_index=True):
             docs = fetch_documents_from_es2(doc_type, from_=offset, page_size=page_size, index_name=index_name_from)
 
             print('Indexing documents {} to {} into ES5'.format(offset, offset+page_size))
-            if bulk_index:
-                # Bulk index docs to ES5
-                bulk_index_documents_to_es5(index_name_to, doc_type, docs)
-            else:
-                # Post individual docs to ES5
-                index_individual_docs(index_name_to, doc_type, docs)
+            bulk_index_documents_to_es5(index_name_to, doc_type, docs)
 
             offset += page_size
 


### PR DESCRIPTION
This fixes two problems, and now I think all the documents have made it across other than the one page-traffic document with an invalid ID (it looks like the content has ended up in the ID field somehow).

---

Bulk indexing sometimes doesn't work:

- there's one page-traffic document with an invalid ID, which causes the entire batch to be aborted

- the employment_appeal_tribunal_decision, utaac_decision, and tax_tribunal_decision types seem to have some large documents, which causes a batch to sometimes time out

However, bulk indexing is way faster than individually indexing documents.  So we want to keep it in general (especially for the page-traffic documents, there are a lot of those).  So, if a bulk index fails, instead try to individually index that batch.

---

Fetch documents using the scroll API, rather than repeated searches.  The scroll API gives you a consistent view of a large (ie, bigger than a single page) set of results, whereas repeated searches do not.

I expected this to maybe bring across a few hundred extra documents at most, where an insert during the indexing process had caused the page numbers to get out of whack.  However, it seems to have fixed the thousands of missing documents.

---

[Trello card](https://trello.com/c/s2fEDmSV/44-create-a-method-for-verifying-reindexing-has-been-successful-and-not-lost-duplicated-data)