### PR TITLE
Drop page size for bulk reindex to 250

### DIFF
--- a/scripts/bulk_index_es2_to_es5.py
+++ b/scripts/bulk_index_es2_to_es5.py
@@ -151,7 +151,7 @@ def copy_index(index_name_from, index_name_to):
 
     for doc_type, dcount in iteritems(es2_doc_counts):
         offset = 0
-        page_size = 500
+        page_size = 250
 
         print('Preparing to index {} {} document(s) from ES2 {} index'.format(dcount, doc_type, index_name_from))
 


### PR DESCRIPTION
I had some problems in staging with missing documents, which persisted
after two attempts with a page size of 500.  I decreased the size to
250, and it worked first time.  I'm surprised that no error is being
thrown, but this seems to fix whatever problem there is...

---

[Trello card](https://trello.com/c/YU9bS9jR/76-get-search-api-running-in-aws-staging)